### PR TITLE
GraphQL Endpoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,25 @@
 # Python: Rivian API Client
 
 Currently a Work In Progress
+
+## Dependencies
+
+[Poetry](https://python-poetry.org/docs/)
+
+```
+curl -sSL https://install.python-poetry.org | python3 -
+```
+
+## Setup
+
+Install project dependencies into the poetry virtual environment.
+
+```
+poetry install
+```
+
+## Run Tests
+
+```
+poetry run pytest
+```

--- a/src/rivian/rivian.py
+++ b/src/rivian/rivian.py
@@ -18,6 +18,17 @@ from rivian.exceptions import RivianExpiredTokenError
 
 _LOGGER = logging.getLogger(__name__)
 
+CESIUM_BASEPATH = "https://cesium.rivianservices.com/v2"
+AUTH_BASEPATH = "https://auth.rivianservices.com/auth/api/v1"
+GRAPHQL_BASEPATH = "https://rivian.com/api/gql"
+GRAPHQL_GATEWAY = GRAPHQL_BASEPATH + "/gateway/graphql"
+GRAPHQL_CHARGING = GRAPHQL_BASEPATH + "/chrg/user/graphql"
+
+BASE_HEADERS = {
+    "User-Agent": "RivianApp/707 CFNetwork/1237 Darwin/20.4.0",
+    "Accept": "application/json",
+    "Content-Type": "application/json",
+}
 
 class Rivian:
     """Main class for the Rivian API Client"""
@@ -47,13 +58,10 @@ class Rivian:
         password: str,
     ) -> ClientRequest:
         """Authenticate against the Rivian API with Username and Password"""
-        url = "https://auth.rivianservices.com/auth/api/v1/token/auth"
+        url = url = AUTH_BASEPATH + "/token/auth"
 
-        headers = {
-            "User-Agent": "RivianApp/707 CFNetwork/1237 Darwin/20.4.0",
-            "Accept": "application/json",
-            "Content-Type": "application/json",
-        }
+        headers = dict()
+        headers.update(BASE_HEADERS)
 
         json_data = {
             "grant_type": "password",
@@ -115,14 +123,13 @@ class Rivian:
         otp: str,
     ) -> dict[str, Any]:
         """Validate the OTP"""
-        url = "https://auth.rivianservices.com/auth/api/v1/token/auth"
+        url = url = AUTH_BASEPATH + "/token/auth"
 
-        headers = {
-            "User-Agent": "RivianApp/707 CFNetwork/1237 Darwin/20.4.0",
-            "Accept": "application/json",
-            "Content-Type": "application/json",
+        headers = dict()
+        headers.update(BASE_HEADERS)
+        headers.update({
             "Authorization": "Bearer " + self._session_token,
-        }
+        })
 
         json_data = {
             "grant_type": "password",
@@ -179,13 +186,10 @@ class Rivian:
         client_secret: str,
     ) -> ClientRequest:
         """Validate the OTP"""
-        url = "https://auth.rivianservices.com/auth/api/v1/token/refresh"
+        url = url = AUTH_BASEPATH + "/token/refresh"
 
-        headers = {
-            "User-Agent": "RivianApp/707 CFNetwork/1237 Darwin/20.4.0",
-            "Accept": "application/json",
-            "Content-Type": "application/json",
-        }
+        headers = dict()
+        headers.update(BASE_HEADERS)
 
         json_data = {
             "token": refresh_token,
@@ -233,18 +237,18 @@ class Rivian:
 
         return response
 
+
     async def get_vehicle_info(
         self, vin: str, access_token: str, properties: dict[str]
     ) -> dict[str, Any]:
         """get the vehicle info"""
-        url = "https://cesium.rivianservices.com/v2/vehicle/latest"
+        url = CESIUM_BASEPATH + "/vehicle/latest"
 
-        headers = {
-            "User-Agent": "RivianApp/707 CFNetwork/1237 Darwin/20.4.0",
-            "Accept": "application/json",
-            "Content-Type": "application/json",
-            "Authorization": "Bearer " + access_token,
-        }
+        headers = dict()
+        headers.update(BASE_HEADERS)
+        headers.update({
+            "Authorization": "Bearer " + self._session_token,
+        })
 
         json_data = {
             "car": vin,
@@ -272,8 +276,6 @@ class Rivian:
                 "Error occurred while communicating with Rivian."
             ) from exception
 
-        content_type = response.headers.get("Content-Type", "")
-
         if response.status // 100 in [4, 5]:
             contents = await response.read()
             response.close()
@@ -295,6 +297,220 @@ class Rivian:
             )
 
         return response
+
+    async def create_csrf_token(
+        self
+    ) -> dict[str, Any]:
+        """create cross-site-request-forgery (csrf) token"""
+        
+        url = GRAPHQL_GATEWAY
+
+        headers = dict()
+        headers.update(BASE_HEADERS)
+
+        graphql_json = {
+            "operationName": "CreateCSRFToken",
+            "query": "mutation CreateCSRFToken {\n  createCsrfToken {\n    __typename\n    csrfToken\n    appSessionToken\n  }\n}",
+            "variables": None
+        }
+
+        response = await self.__graphql_query(headers, url, graphql_json)
+        
+        response_json = await response.json()
+
+        csrf_data = response_json["data"]["createCsrfToken"]
+        self._csrf_token = csrf_data["csrfToken"]
+        self._app_session_token = csrf_data["appSessionToken"]
+
+        return response
+
+    
+    async def authenticate_graphql(
+        self, 
+        username: str,
+        password: str,
+    ) -> dict[str, Any]:
+        """Authenticate against the Rivian GraphQL API with Username and Password"""
+        
+        url = GRAPHQL_GATEWAY
+
+        headers = dict()
+        headers.update(BASE_HEADERS)
+        headers.update({
+            "Csrf-Token": self._csrf_token,
+            "A-Sess": self._app_session_token,
+            "Apollographql-Client-Name": "com.rivian.ios.consumer-apollo-ios"
+        })
+
+        graphql_json = {
+            "operationName": "Login",
+            "query": "mutation Login($email: String!, $password: String!) {\n  login(email: $email, password: $password) {\n    __typename\n    ... on MobileLoginResponse {\n      __typename\n      accessToken\n      refreshToken\n      userSessionToken\n    }\n    ... on MobileMFALoginResponse {\n      __typename\n      otpToken\n    }\n  }\n}",
+            "variables": {
+                "email": username,
+                "password": password
+            }
+        }
+
+        response = await self.__graphql_query(headers, url, graphql_json)
+        
+        response_json = await response.json()
+        self._access_token = response_json["data"]["login"]["accessToken"]
+        self._refresh_token = response_json["data"]["login"]["refreshToken"]
+        self._user_session_token = response_json["data"]["login"]["userSessionToken"]
+        
+        return response
+
+
+    async def get_user_information(
+        self
+    ) -> ClientResponse:
+        """get user information (user.id, vehicle vins)"""
+        url = GRAPHQL_GATEWAY
+        
+        headers = dict()
+        headers.update(BASE_HEADERS)
+        headers.update({
+            "A-Sess": self._app_session_token,
+            "U-Sess": self._user_session_token
+        })
+        
+        graphql_json = {
+            "operationName": "getUserInfo",
+            "query": "query getUserInfo {\n    currentUser {\n        __typename\n        id\n        vehicles {\n        id\n        vin\n        vas {\n            __typename\n            vasVehicleId\n            vehiclePublicKey\n        }\n        roles\n        state\n        createdAt\n        updatedAt\n        vehicle {\n            __typename\n            id\n            vin\n            modelYear\n            make\n            model\n            expectedBuildDate\n            plannedBuildDate\n            expectedGeneralAssemblyStartDate\n            actualGeneralAssemblyDate\n        }\n        }\n    }\n}",
+            "variables": None
+        }
+
+        return await self.__graphql_query(headers, url, graphql_json)
+
+
+    async def get_registered_wallboxes(
+        self
+    ) -> ClientResponse:
+        """get wallboxes (graphql)"""
+        url = GRAPHQL_CHARGING
+        
+        headers = dict()
+        headers.update(BASE_HEADERS)
+        headers.update({
+            "Csrf-Token": self._csrf_token,
+            "A-Sess": self._app_session_token,
+            "U-Sess": self._user_session_token
+        })
+        
+        graphql_json = {
+            "operationName": "getRegisteredWallboxes",
+            "query": "query getRegisteredWallboxes {\n  getRegisteredWallboxes {\n    __typename\n    wallboxId\n    userId\n    wifiId\n    name\n    linked\n    latitude\n    longitude\n    chargingStatus\n    power\n    currentVoltage\n    currentAmps\n    softwareVersion\n    model\n    serialNumber\n    maxAmps\n    maxVoltage\n    maxPower\n  }\n}",
+            "variables": None
+        }
+
+        return await self.__graphql_query(headers, url, graphql_json)
+    
+
+    async def get_vehicle_state(
+        self, vin: str, properties: dict[str]
+    ) -> ClientResponse:
+        """get vehicle state (graphql)"""
+        url = GRAPHQL_GATEWAY
+        
+        headers = dict()
+        headers.update(BASE_HEADERS)
+        headers.update({
+            "A-Sess": self._app_session_token,
+            "U-Sess": self._user_session_token
+        })
+
+        graphql_query = "query GetVehicleState($vehicleID: String!) {\n  vehicleState(id: $vehicleID) {\n    __typename\n:   "
+        gnss_attribute_template = "{\n      __typename\n      latitude\n      longitude\n      timeStamp\n    }\n"
+        generic_sensor_template = "{\n      __typename\n      timeStamp\n      value\n    }\n"
+
+        for key in properties:
+            template = generic_sensor_template
+            if key == 'gnssLocation':
+                template = gnss_attribute_template
+        
+            graphql_query += f'{key} {template}'
+        graphql_query += '}'
+        
+        graphql_json = {
+            "operationName":"GetVehicleState",
+            "query":graphql_query,
+            "variables": { 
+                "vehicleID": vin
+            }
+        }
+
+        return await self.__graphql_query(headers, url, graphql_json)
+
+
+    async def get_live_charging_session(
+        self, user_id: str, vin: str, properties: dict[str]
+    ) -> ClientResponse:
+        """get live charging session data (graphql)"""
+        url = GRAPHQL_CHARGING
+        
+        headers = dict()
+        headers.update(BASE_HEADERS)
+        headers.update({
+            "U-Sess": self._user_session_token
+        })
+
+        graphql_query = "query getLiveSessionData($vehicleId: ID!) {\n  getLiveSessionData(vehicleId: $vehicleId) {\n    __typename\n:   "
+        detail_sensors = ['vehicleChargerState', 'timeRemaining', 'kilometersChargedPerHour', 'power', 'rangeAddedThisSession', 'totalChargedEnergy']
+        detail_sensor_template = "{\n      __typename\n      value\n      updatedAt\n    }\n"
+
+        for key in properties:
+            template = ''
+            if key in detail_sensors:
+                template = detail_sensor_template
+            graphql_query += f'{key} {template}'
+        graphql_query += '}'
+        
+        graphql_json = {
+            "operationName":"getLiveSessionData",
+            "query":graphql_query,
+            "variables": { 
+                "userId": user_id,
+                "vehicleId": vin
+            }
+        }
+
+        return await self.__graphql_query(headers, url, graphql_json)
+
+
+    async def __graphql_query(
+        self, headers: dict(str, str), url: str, body: str
+    ):
+        """execute and return arbitrary graphql query"""
+        if self._session is None:
+            self._session = aiohttp.ClientSession()
+            self._close_session = True
+
+        try:
+            async with async_timeout.timeout(self.request_timeout):
+                response = await self._session.request(
+                    "POST",
+                    url,
+                    json=body,
+                    headers=headers,
+                )
+        except asyncio.TimeoutError as exception:
+            raise Exception(
+                "Timeout occurred while connecting to Rivian API."
+            ) from exception
+        except (aiohttp.ClientError, socket.gaierror) as exception:
+            raise Exception(
+                "Error occurred while communicating with Rivian."
+            ) from exception
+
+        if response.status != 200:
+            raise Exception("Error occurred while reading the graphql response from Rivian.")
+            
+        response_json = await response.json()
+        if 'errors' in response_json:
+            raise Exception("Error occurred while reading the graphql response from Rivian.")
+        
+        return response
+
 
     async def close(self) -> None:
         """Close open client session."""

--- a/tests/rivian_test.py
+++ b/tests/rivian_test.py
@@ -164,3 +164,575 @@ async def test_expired_access_token_throws_exception(aresponses):
 
             await rivian.close()
 
+
+@pytest.mark.asyncio
+async def test_graphql_csrf_token_request(aresponses):
+    """Test GraphQL Response for a CSRF token request"""
+    aresponses.add(
+        "rivian.com",
+        "/api/gql/gateway/graphql",
+        "POST",
+        aresponses.Response(
+            status=200,
+            headers={
+                "Content-Type": "application/json:"
+            },
+            text='''{
+                "data": {
+                    "createCsrfToken": {
+                        "__typename": "CreateCsrfTokenResponse",
+                        "csrfToken": "valid_csrf_token",
+                        "appSessionToken": "valid_app_session_token"
+                    }
+                }
+            }'''
+        ),
+    )
+    async with aiohttp.ClientSession() as session:
+        rivian = Rivian("abcd1234", "wxyz9876")
+        response = await rivian.create_csrf_token()
+        response_json = await response.json()
+        assert response.status == 200
+        assert rivian._csrf_token == "valid_csrf_token"
+        assert rivian._app_session_token == "valid_app_session_token"
+        await rivian.close()
+
+
+@pytest.mark.asyncio
+async def test_graphql_authenticate_request(aresponses):
+    """Test GraphQL Response for a Authentication request"""
+    aresponses.add(
+        "rivian.com",
+        "/api/gql/gateway/graphql",
+        "POST",
+        aresponses.Response(
+            status=200,
+            headers={
+                "Content-Type": "application/json:"
+            },
+            text='''{
+                "data": {
+                    "login": {
+                        "__typename": "MobileLoginResponse",
+                        "accessToken": "valid_access_token",
+                        "refreshToken": "valid_refresh_token",
+                        "userSessionToken": "valid_user_session_token"
+                    }
+                }
+            }'''
+        ),
+    )
+    async with aiohttp.ClientSession() as session:
+        rivian = Rivian("abcd1234", "wxyz9876")
+        rivian._csrf_token = "token"
+        rivian._app_session_token = "token"
+        response = await rivian.authenticate_graphql("username", "password")
+        response_json = await response.json()
+        assert response.status == 200
+        assert rivian._access_token == "valid_access_token"
+        assert rivian._refresh_token == "valid_refresh_token"
+        assert rivian._user_session_token == "valid_user_session_token"
+        await rivian.close()
+
+
+@pytest.mark.asyncio
+async def test_get_registered_wallboxes(aresponses):
+    """Test GraphQL Response for a getRegisteredWallboxes request"""
+    aresponses.add(
+        "rivian.com",
+        "/api/gql/chrg/user/graphql",
+        "POST",
+        aresponses.Response(
+            status=200,
+            headers={
+                "Content-Type": "application/json:"
+            },
+            text='''{
+                "data": {
+                    "getRegisteredWallboxes": [{
+                        "__typename": "WallboxRecord",
+                        "wallboxId": "W1-1113-3RV7-1-1234-00012",
+                        "userId": "01-2a3259ba-0be3-42a7-bf82-69adea27dcdd-2b4532cd",
+                        "wifiId": "Network",
+                        "name": "Wall Charger",
+                        "linked": true,
+                        "latitude": "42.3601866",
+                        "longitude": "-71.0589682",
+                        "chargingStatus": "AVAILABLE",
+                        "power": null,
+                        "currentVoltage": null,
+                        "currentAmps": null,
+                        "softwareVersion": "V03.01.47",
+                        "model": "W1-1113-3RV7",
+                        "serialNumber": "W1-1113-3RV7-1-1234-00012",
+                        "maxAmps": null,
+                        "maxVoltage": "224.0",
+                        "maxPower": "11000"
+                    }]
+                }
+            }'''
+        ),
+    )
+    async with aiohttp.ClientSession() as session:
+        rivian = Rivian("abcd1234", "wxyz9876")
+        rivian._csrf_token = "token"
+        rivian._app_session_token = "token"
+        rivian._user_session_token = "token"
+        response = await rivian.get_registered_wallboxes()
+        response_json = await response.json()
+        assert response.status == 200
+        assert len(response_json['data']['getRegisteredWallboxes']) == 1
+        assert response_json['data']['getRegisteredWallboxes'][0]["wallboxId"] == "W1-1113-3RV7-1-1234-00012"
+        await rivian.close()
+
+@pytest.mark.asyncio
+async def test_get_vehicle_state(aresponses):
+    """Test GraphQL Response for a vehicleState request"""
+    aresponses.add(
+        "rivian.com",
+        "/api/gql/gateway/graphql",
+        "POST",
+        aresponses.Response(
+            status=200,
+            headers={
+                "Content-Type": "application/json:"
+            },
+            text='''{
+                "data": {
+                    "vehicleState": {
+                        "__typename": "VehicleState",
+                        "gnssLocation": {
+                            "__typename": "VehicleLocation",
+                            "latitude": 42.3601866,
+                            "longitude": -71.0589682,
+                            "timeStamp": "2022-10-26T20:07:01.081Z"
+                        },
+                        "alarmSoundStatus": {
+                            "__typename": "TimeStampedString",
+                            "timeStamp": "2022-10-07T04:42:39.880Z",
+                            "value": "false"
+                        },
+                        "timeToEndOfCharge": {
+                            "__typename": "TimeStampedFloat",
+                            "timeStamp": "2022-10-26T20:04:38.716Z",
+                            "value": 0
+                        },
+                        "doorFrontLeftLocked": {
+                            "__typename": "TimeStampedString",
+                            "timeStamp": "2022-10-26T19:45:39.179Z",
+                            "value": "locked"
+                        },
+                        "doorFrontLeftClosed": {
+                            "__typename": "TimeStampedString",
+                            "timeStamp": "2022-10-26T19:45:39.179Z",
+                            "value": "closed"
+                        },
+                        "doorFrontRightLocked": {
+                            "__typename": "TimeStampedString",
+                            "timeStamp": "2022-10-26T19:45:39.179Z",
+                            "value": "locked"
+                        },
+                        "doorFrontRightClosed": {
+                            "__typename": "TimeStampedString",
+                            "timeStamp": "2022-10-26T19:45:39.179Z",
+                            "value": "closed"
+                        },
+                        "doorRearLeftLocked": {
+                            "__typename": "TimeStampedString",
+                            "timeStamp": "2022-10-26T19:45:39.179Z",
+                            "value": "locked"
+                        },
+                        "doorRearLeftClosed": {
+                            "__typename": "TimeStampedString",
+                            "timeStamp": "2022-10-26T19:45:39.179Z",
+                            "value": "closed"
+                        },
+                        "doorRearRightLocked": {
+                            "__typename": "TimeStampedString",
+                            "timeStamp": "2022-10-26T19:45:39.179Z",
+                            "value": "locked"
+                        },
+                        "doorRearRightClosed": {
+                            "__typename": "TimeStampedString",
+                            "timeStamp": "2022-10-26T19:45:39.179Z",
+                            "value": "closed"
+                        },
+                        "windowFrontLeftClosed": {
+                            "__typename": "TimeStampedString",
+                            "timeStamp": "2022-10-26T19:45:39.179Z",
+                            "value": "closed"
+                        },
+                        "windowFrontRightClosed": {
+                            "__typename": "TimeStampedString",
+                            "timeStamp": "2022-10-26T19:45:39.179Z",
+                            "value": "closed"
+                        },
+                        "windowFrontLeftCalibrated": {
+                            "__typename": "TimeStampedString",
+                            "timeStamp": "2022-10-26T19:45:39.179Z",
+                            "value": "Calibrated"
+                        },
+                        "windowFrontRightCalibrated": {
+                            "__typename": "TimeStampedString",
+                            "timeStamp": "2022-10-26T19:45:39.179Z",
+                            "value": "Calibrated"
+                        },
+                        "windowRearLeftCalibrated": {
+                            "__typename": "TimeStampedString",
+                            "timeStamp": "2022-10-26T19:45:39.179Z",
+                            "value": "Calibrated"
+                        },
+                        "windowRearRightCalibrated": {
+                            "__typename": "TimeStampedString",
+                            "timeStamp": "2022-10-26T19:45:39.179Z",
+                            "value": "Calibrated"
+                        },
+                        "closureFrunkLocked": {
+                            "__typename": "TimeStampedString",
+                            "timeStamp": "2022-10-26T19:45:39.179Z",
+                            "value": "locked"
+                        },
+                        "closureFrunkClosed": {
+                            "__typename": "TimeStampedString",
+                            "timeStamp": "2022-10-26T19:45:39.179Z",
+                            "value": "closed"
+                        },
+                        "gearGuardLocked": {
+                            "__typename": "TimeStampedString",
+                            "timeStamp": "2022-10-26T19:45:39.179Z",
+                            "value": "unlocked"
+                        },
+                        "closureLiftgateLocked": {
+                            "__typename": "TimeStampedString",
+                            "timeStamp": "2022-10-26T19:45:39.179Z",
+                            "value": "locked"
+                        },
+                        "closureLiftgateClosed": {
+                            "__typename": "TimeStampedString",
+                            "timeStamp": "2022-10-26T19:45:39.179Z",
+                            "value": "signal_not_available"
+                        },
+                        "windowRearLeftClosed": {
+                            "__typename": "TimeStampedString",
+                            "timeStamp": "2022-10-26T19:45:39.179Z",
+                            "value": "closed"
+                        },
+                        "windowRearRightClosed": {
+                            "__typename": "TimeStampedString",
+                            "timeStamp": "2022-10-26T19:45:39.179Z",
+                            "value": "closed"
+                        },
+                        "closureSideBinLeftLocked": {
+                            "__typename": "TimeStampedString",
+                            "timeStamp": "2022-10-26T19:45:39.179Z",
+                            "value": "locked"
+                        },
+                        "closureSideBinLeftClosed": {
+                            "__typename": "TimeStampedString",
+                            "timeStamp": "2022-10-26T19:45:39.179Z",
+                            "value": "closed"
+                        },
+                        "closureSideBinRightLocked": {
+                            "__typename": "TimeStampedString",
+                            "timeStamp": "2022-10-26T19:45:39.179Z",
+                            "value": "locked"
+                        },
+                        "closureSideBinRightClosed": {
+                            "__typename": "TimeStampedString",
+                            "timeStamp": "2022-10-26T19:45:39.179Z",
+                            "value": "closed"
+                        },
+                        "closureTailgateLocked": {
+                            "__typename": "TimeStampedString",
+                            "timeStamp": "2022-10-26T19:45:39.179Z",
+                            "value": "locked"
+                        },
+                        "closureTailgateClosed": {
+                            "__typename": "TimeStampedString",
+                            "timeStamp": "2022-10-26T19:45:39.179Z",
+                            "value": "closed"
+                        },
+                        "closureTonneauLocked": {
+                            "__typename": "TimeStampedString",
+                            "timeStamp": "2022-10-26T19:45:39.179Z",
+                            "value": "locked"
+                        },
+                        "closureTonneauClosed": {
+                            "__typename": "TimeStampedString",
+                            "timeStamp": "2022-10-26T19:45:39.179Z",
+                            "value": "closed"
+                        },
+                        "wiperFluidState": {
+                            "__typename": "TimeStampedString",
+                            "timeStamp": "2022-10-14T01:01:22.260Z",
+                            "value": "normal"
+                        },
+                        "powerState": {
+                            "__typename": "TimeStampedString",
+                            "timeStamp": "2022-10-26T19:46:39.763Z",
+                            "value": "ready"
+                        },
+                        "batteryHvThermalEventPropagation": {
+                            "__typename": "TimeStampedString",
+                            "timeStamp": "2022-10-26T16:58:03.936Z",
+                            "value": "off"
+                        },
+                        "vehicleMileage": {
+                            "__typename": "TimeStampedInt",
+                            "timeStamp": "2022-10-26T19:43:13.847Z",
+                            "value": 8928840
+                        },
+                        "brakeFluidLow": null,
+                        "gearStatus": {
+                            "__typename": "TimeStampedString",
+                            "timeStamp": "2022-10-26T19:43:18.344Z",
+                            "value": "park"
+                        },
+                        "tirePressureStatusFrontLeft": {
+                            "__typename": "TimeStampedString",
+                            "timeStamp": "2022-10-26T19:39:27.589Z",
+                            "value": "OK"
+                        },
+                        "tirePressureStatusValidFrontLeft": {
+                            "__typename": "TimeStampedString",
+                            "timeStamp": "2022-10-26T19:39:27.589Z",
+                            "value": "valid"
+                        },
+                        "tirePressureStatusFrontRight": {
+                            "__typename": "TimeStampedString",
+                            "timeStamp": "2022-10-26T19:39:27.589Z",
+                            "value": "OK"
+                        },
+                        "tirePressureStatusValidFrontRight": {
+                            "__typename": "TimeStampedString",
+                            "timeStamp": "2022-10-26T19:39:27.589Z",
+                            "value": "valid"
+                        },
+                        "tirePressureStatusRearLeft": {
+                            "__typename": "TimeStampedString",
+                            "timeStamp": "2022-10-26T19:39:27.589Z",
+                            "value": "OK"
+                        },
+                        "tirePressureStatusValidRearLeft": {
+                            "__typename": "TimeStampedString",
+                            "timeStamp": "2022-10-26T19:39:27.589Z",
+                            "value": "valid"
+                        },
+                        "tirePressureStatusRearRight": {
+                            "__typename": "TimeStampedString",
+                            "timeStamp": "2022-10-26T19:39:27.589Z",
+                            "value": "OK"
+                        },
+                        "tirePressureStatusValidRearRight": {
+                            "__typename": "TimeStampedString",
+                            "timeStamp": "2022-10-26T19:39:27.589Z",
+                            "value": "valid"
+                        },
+                        "batteryLevel": {
+                            "__typename": "TimeStampedFloat",
+                            "timeStamp": "2022-10-26T19:46:30.360Z",
+                            "value": 53.400002
+                        },
+                        "chargerState": {
+                            "__typename": "TimeStampedString",
+                            "timeStamp": "2022-10-26T18:00:45.533Z",
+                            "value": "charging_ready"
+                        },
+                        "batteryHvThermalEvent": {
+                            "__typename": "TimeStampedString",
+                            "timeStamp": "2022-10-26T19:40:08.035Z",
+                            "value": "nominal"
+                        },
+                        "rangeThreshold": {
+                            "__typename": "TimeStampedString",
+                            "timeStamp": "2022-10-26T19:40:08.035Z",
+                            "value": "vehicle_range_normal"
+                        },
+                        "distanceToEmpty": {
+                            "__typename": "TimeStampedInt",
+                            "timeStamp": "2022-10-26T19:38:56.266Z",
+                            "value": 266
+                        },
+                        "otaAvailableVersionNumber": {
+                            "__typename": "TimeStampedInt",
+                            "timeStamp": "2022-10-07T09:07:17.231Z",
+                            "value": 0
+                        },
+                        "otaAvailableVersionWeek": {
+                            "__typename": "TimeStampedInt",
+                            "timeStamp": "2022-10-07T09:07:17.231Z",
+                            "value": 0
+                        },
+                        "otaAvailableVersionYear": {
+                            "__typename": "TimeStampedInt",
+                            "timeStamp": "2022-10-07T09:07:17.231Z",
+                            "value": 0
+                        },
+                        "otaCurrentVersionNumber": {
+                            "__typename": "TimeStampedInt",
+                            "timeStamp": "2022-10-07T09:07:17.231Z",
+                            "value": 3
+                        },
+                        "otaCurrentVersionWeek": {
+                            "__typename": "TimeStampedInt",
+                            "timeStamp": "2022-10-07T09:07:17.231Z",
+                            "value": 35
+                        },
+                        "otaCurrentVersionYear": {
+                            "__typename": "TimeStampedInt",
+                            "timeStamp": "2022-10-07T09:07:17.231Z",
+                            "value": 2022
+                        },
+                        "otaDownloadProgress": {
+                            "__typename": "TimeStampedInt",
+                            "timeStamp": "2022-10-07T09:07:17.231Z",
+                            "value": 0
+                        },
+                        "otaInstallDuration": {
+                            "__typename": "TimeStampedInt",
+                            "timeStamp": "2022-10-07T09:07:17.231Z",
+                            "value": 0
+                        },
+                        "otaInstallProgress": {
+                            "__typename": "TimeStampedInt",
+                            "timeStamp": "2022-10-07T09:07:17.231Z",
+                            "value": 0
+                        },
+                        "otaInstallReady": {
+                            "__typename": "TimeStampedString",
+                            "timeStamp": "2022-10-26T19:43:18.428Z",
+                            "value": "ota_available"
+                        },
+                        "otaInstallTime": {
+                            "__typename": "TimeStampedInt",
+                            "timeStamp": "2022-10-07T09:07:17.231Z",
+                            "value": 0
+                        },
+                        "otaInstallType": {
+                            "__typename": "TimeStampedString",
+                            "timeStamp": "2022-10-07T09:07:17.231Z",
+                            "value": "Convenience"
+                        },
+                        "otaStatus": {
+                            "__typename": "TimeStampedString",
+                            "timeStamp": "2022-10-07T09:07:17.231Z",
+                            "value": "Idle"
+                        },
+                        "otaCurrentStatus": {
+                            "__typename": "TimeStampedString",
+                            "timeStamp": "2022-10-07T09:07:17.231Z",
+                            "value": "Install_Success"
+                        },
+                        "cabinClimateInteriorTemperature": {
+                            "__typename": "TimeStampedFloat",
+                            "timeStamp": "2022-10-26T20:07:04.559Z",
+                            "value": 21
+                        },
+                        "cabinClimateDriverTemperature": {
+                            "__typename": "TimeStampedFloat",
+                            "timeStamp": "2022-10-26T20:07:04.559Z",
+                            "value": 20
+                        },
+                        "cabinPreconditioningStatus": {
+                            "__typename": "TimeStampedString",
+                            "timeStamp": "2022-10-26T19:45:39.808Z",
+                            "value": "undefined"
+                        },
+                        "cabinPreconditioningType": {
+                            "__typename": "TimeStampedString",
+                            "timeStamp": "2022-10-26T19:45:39.808Z",
+                            "value": "NONE"
+                        },
+                        "petModeStatus": {
+                            "__typename": "TimeStampedString",
+                            "timeStamp": "2022-10-26T19:43:18.485Z",
+                            "value": "Off"
+                        },
+                        "petModeTemperatureStatus": {
+                            "__typename": "TimeStampedString",
+                            "timeStamp": "2022-10-26T19:43:18.485Z",
+                            "value": "Default"
+                        }
+                    }
+                }
+            }'''
+        ),
+    )
+    async with aiohttp.ClientSession() as session:
+        rivian = Rivian("abcd1234", "wxyz9876")
+        rivian._app_session_token = "token"
+        rivian._user_session_token = "token"
+        properties = dict()
+        response = await rivian.get_vehicle_state("vin", properties)
+        response_json = await response.json()
+        assert response.status == 200
+        assert len(response_json['data']['vehicleState']) == 72
+        await rivian.close()
+
+
+@pytest.mark.asyncio
+async def test_get_live_charging_session(aresponses):
+    """Test GraphQL Response for a getLiveSessionData request"""
+    aresponses.add(
+        "rivian.com",
+        "/api/gql/chrg/user/graphql",
+        "POST",
+        aresponses.Response(
+            status=200,
+            headers={
+                "Content-Type": "application/json:"
+            },
+            text='''{
+                "data": {
+                    "getLiveSessionData": {
+                        "isRivianCharger": null,
+                        "isFreeSession": null,
+                        "vehicleChargerState": {
+                            "__typename": "StringValueRecord",
+                            "value": "charging_active",
+                            "updatedAt": "2022-10-27T21:25:16.226Z"
+                        },
+                        "chargerId": null,
+                        "startTime": "2022-10-27T20:48:27.222Z",
+                        "timeElapsed": "2229",
+                        "timeRemaining": {
+                            "__typename": "StringValueRecord",
+                            "value": "9651",
+                            "updatedAt": "2022-10-27T21:25:27.222Z"
+                        },
+                        "kilometersChargedPerHour": {
+                            "__typename": "FloatValueRecord",
+                            "value": 32,
+                            "updatedAt": "2022-10-27T21:25:25.149Z"
+                        },
+                        "power": {
+                            "__typename": "FloatValueRecord",
+                            "value": 9,
+                            "updatedAt": "2022-10-27T21:25:16.226Z"
+                        },
+                        "rangeAddedThisSession": {
+                            "__typename": "FloatValueRecord",
+                            "value": 20,
+                            "updatedAt": "2022-10-27T21:25:25.149Z"
+                        },
+                        "totalChargedEnergy": {
+                            "__typename": "FloatValueRecord",
+                            "value": 6,
+                            "updatedAt": "2022-10-27T21:25:16.226Z"
+                        },
+                        "currentPrice": null
+                    }
+                }
+            }'''
+        ),
+    )
+    async with aiohttp.ClientSession() as session:
+        rivian = Rivian("abcd1234", "wxyz9876")
+        rivian._app_session_token = "token"
+        rivian._user_session_token = "token"
+        properties = dict()
+        response = await rivian.get_live_charging_session("userId", "vin", properties)
+        response_json = await response.json()
+        assert response.status == 200
+        assert response_json['data']['getLiveSessionData']['vehicleChargerState']['value'] == "charging_active"
+        await rivian.close()


### PR DESCRIPTION
Initial implementation adding in some graphql endpoints discovered.
- `create_csrf_token()` -> create cross-site-request-forgory token used for exchanging for a session
    - will mutate self and store self._csrf_token
- `authenticate_graphql()` -> graphql authenticate mutation for app session and user session tokens used with other graphql query and mutation requests
    - will mutate self and store self._user_session_token
    - will mutate self and store self._app_session_token
- `get_user_information()` -> graphql query to get a subset of user information (id, vin, and vehicle make/model, etc) choose not to include email, name, phone, addresses, and other PII/PD data that is available via that call (could always add it in later as needed?)
- `get_registered_wallboxes()` -> get a list of wallbox charger data (serial number, etc)
- `get_vehicle_state(vin, properties)` -> graphql replacement of get_vehicle_info(vin, access_token, properties)
- `get_live_charging_session(user_id, vin)` -> graphql query to retrieve live charging information (only returns live charging data, no charging history)


@jrgutier this is what we are going to need to switch HA over to leverage the graphql queries.