### PR TITLE
fix the refactor issue that removed the access_token

### DIFF
--- a/src/rivian/rivian.py
+++ b/src/rivian/rivian.py
@@ -247,7 +247,7 @@ class Rivian:
         headers = dict()
         headers.update(BASE_HEADERS)
         headers.update({
-            "Authorization": "Bearer " + self._access_token,
+            "Authorization": "Bearer " + access_token,
         })
 
         json_data = {


### PR DESCRIPTION
There was an oversight in the refactor that removed `"Bearer: " + access_token` from the method, I've added that back.

Would have added a test for this, but https://github.com/aresponses/aresponses/ doesn't have support for filtering request matches by incoming headers.