### PR TITLE
keep response context available for naive exception handling

### DIFF
--- a/src/rivian/rivian.py
+++ b/src/rivian/rivian.py
@@ -500,14 +500,21 @@ class Rivian:
             ) from exception
 
         if response.status != 200:
+            body = await response.text()
             raise Exception(
-                "Error occurred while reading the graphql response from Rivian."
+                "Error occurred while reading the graphql response from Rivian.",
+                response,
+                response.status,
+                body,
             )
 
         response_json = await response.json()
         if "errors" in response_json:
             raise Exception(
-                "Error occurred while reading the graphql response from Rivian."
+                "Error occurred while reading the graphql response from Rivian.",
+                response,
+                response.status,
+                response_json,
             )
 
         return response


### PR DESCRIPTION
as a quick way to keep response.body intact for downstream error handling of graphql (before we build in proper exceptions)