### PR TITLE
Update user agent to reflect latest iOS app version

### DIFF
--- a/src/rivian/rivian.py
+++ b/src/rivian/rivian.py
@@ -26,7 +26,7 @@ GRAPHQL_GATEWAY = GRAPHQL_BASEPATH + "/gateway/graphql"
 GRAPHQL_CHARGING = GRAPHQL_BASEPATH + "/chrg/user/graphql"
 
 BASE_HEADERS = {
-    "User-Agent": "RivianApp/707 CFNetwork/1237 Darwin/20.4.0",
+    "User-Agent": "RivianApp/1304 CFNetwork/1404.0.5 Darwin/22.3.0",
     "Accept": "application/json",
     "Content-Type": "application/json",
     "Apollographql-Client-Name": "com.rivian.ios.consumer-apollo-ios",


### PR DESCRIPTION
Is there any reason not to keep the user agent header up-to-date with the latest iOS app version?

This is the user agent string for my iOS app (version 1.10.1).