### PR TITLE
Add VehicleState fields from 2.19

### DIFF
--- a/src/rivian/schemas/gateway.graphql
+++ b/src/rivian/schemas/gateway.graphql
@@ -635,6 +635,8 @@ type VehicleState {
 
   cloudConnection: VehicleCloudConnection
 
+  coldRangeNotification: TimeStampedString
+
   defrostDefogStatus: TimeStampedString
 
   distanceToEmpty: TimeStampedInt


### PR DESCRIPTION
Add new VehicleState field from 2.19

1. `coldRangeNotification`

Possible values are...

1. RANGE_NORMAL
2. MAY_REDUCE
3. RANGE_REDUCED

Related strings

```xml
    <string name="range_may_reduce_dive_message">Cold weather can cause range loss, especially if your vehicle is out in the cold for a long time.</string>
    <string name="range_may_reduce_dive_message_bullet1">Set a climate schedule to prime the battery for your next drive.</string>
    <string name="range_may_reduce_dive_message_bullet2">Keep the vehicle plugged into a charger.</string>
    <string name="range_may_reduce_dive_message_bullet3">Take the vehicle for a spin. The battery can recover range as it warms up.</string>
    <string name="range_may_reduce_dive_subtitle">Tips for maintaining range:</string>
    <string name="range_may_reduce_message">Cold weather affects range. Set a climate schedule to warm the battery for your next drive.</string>
    <string name="range_may_reduce_title">Range may decrease</string>
    <string name="range_reduced_dive_message_bullet1">Set a climate schedule to prime the battery for your next drive.</string>
    <string name="range_reduced_dive_message_bullet2">Keep the vehicle plugged into a charger.</string>
    <string name="range_reduced_dive_message_bullet3">Take the vehicle for a spin. The battery can recover range as it warms up.</string>
    <string name="range_reduced_dive_subtitle">Here’s what you can do:</string>
    <string name="range_reduced_message">Set a climate schedule or plug into a charger to recover available range for your next drive.</string>
    <string name="range_reduced_title">Range limited by cold</string>
```