### PR TITLE
attributes and cloud commands found from android 2.20 source

### DIFF
--- a/src/rivian/const.py
+++ b/src/rivian/const.py
@@ -34,8 +34,11 @@ VEHICLE_STATE_PROPERTIES: Final[set[str]] = {
     # VehicleCloudConnection
     "cloudConnection",
     # VehicleLocation
+    "geoLocation",
     "gnssLocation",
+    "gnssError",
     # TimeStamped(String|[Nullable]Float|Int)
+    "activeDriverName",
     "alarmSoundStatus",
     "batteryCapacity",
     "batteryCellType",
@@ -59,6 +62,8 @@ VEHICLE_STATE_PROPERTIES: Final[set[str]] = {
     "chargerDerateStatus",
     "chargerState",
     "chargerStatus",
+    "chargePortState",
+    "chargingDisabledAll",
     "closureFrunkClosed",
     "closureFrunkLocked",
     "closureFrunkNextAction",
@@ -96,6 +101,8 @@ VEHICLE_STATE_PROPERTIES: Final[set[str]] = {
     "gnssAltitude",
     "gnssBearing",
     "gnssSpeed",
+    "limitedRegenCold",
+    "limitedAccelCold",
     "otaAvailableVersion",
     "otaAvailableVersionGitHash",
     "otaAvailableVersionNumber",
@@ -118,6 +125,7 @@ VEHICLE_STATE_PROPERTIES: Final[set[str]] = {
     "petModeTemperatureStatus",
     "powerState",
     "rangeThreshold",
+    "rearHitchStatus",
     "remoteChargingAvailable",
     "seatFrontLeftHeat",
     "seatFrontLeftVent",
@@ -157,6 +165,9 @@ VEHICLE_STATES_SUBSCRIPTION_ONLY_PROPERTIES: Final[set[str]] = {
     # TimeStamped(String|[Nullable]Float|Int)
     "activeDriverName",
     "chargingDisabledACFaultState",
+    "chargingTimeEstimationValidity",
+    "chargingTripTargetSoc",
+    "chargingTripTargetMinsRemaining",
     "closureChargePortDoorNextAction",
     "coldRangeNotification",
     "tirePressureFrontLeft",
@@ -174,10 +185,13 @@ class VehicleCommand(StrEnum):
     """Supported vehicle commands."""
 
     WAKE_VEHICLE = "WAKE_VEHICLE"
-    HONK_AND_FLASH_LIGHTS = "HONK_AND_FLASH_LIGHTS"
     UNLOCK_USER_PREFERENCES_AND_DISABLE_ALARM = (
         "UNLOCK_USER_PREFERENCES_AND_DISABLE_ALARM"
     )
+
+    HONK_AND_FLASH_LIGHTS = "HONK_AND_FLASH_LIGHTS"
+    ACTIVATE_EXTERNAL_SOUND = "ACTIVATE_EXTERNAL_SOUND"
+    FLASH_EXTERNAL_LIGHTS = "FLASH_EXTERNAL_LIGHTS"
 
     # Charging
     CHARGING_LIMITS = "CHARGING_LIMITS"
@@ -196,6 +210,9 @@ class VehicleCommand(StrEnum):
     CABIN_PRECONDITIONING_SET_TEMP = "CABIN_PRECONDITIONING_SET_TEMP"
     VEHICLE_CABIN_PRECONDITION_DISABLE = "VEHICLE_CABIN_PRECONDITION_DISABLE"
     VEHICLE_CABIN_PRECONDITION_ENABLE = "VEHICLE_CABIN_PRECONDITION_ENABLE"
+    # Gen2 HVAC Controls
+    CABIN_HVAC_THIRD_ROW_LEFT_SEAT_HEAT = "CABIN_HVAC_THIRD_ROW_LEFT_SEAT_HEAT"
+    CABIN_HVAC_THIRD_ROW_RIGHT_SEAT_HEAT = "CABIN_HVAC_THIRD_ROW_RIGHT_SEAT_HEAT"
 
     # Closures
     LOCK_ALL_CLOSURES_FEEDBACK = "LOCK_ALL_CLOSURES_FEEDBACK"
@@ -218,6 +235,10 @@ class VehicleCommand(StrEnum):
 
     # Liftgate/tailgate
     OPEN_LIFTGATE_UNLATCH_TAILGATE = "OPEN_LIFTGATE_UNLATCH_TAILGATE"
+
+    # Chargeport door
+    OPEN_CHARGE_PORT_DOOR = "OPEN_CHARGE_PORT_DOOR"
+    CLOSE_CHARGE_PORT_DOOR = "CLOSE_CHARGE_PORT_DOOR"
 
     # OTA
     OTA_INSTALL_NOW_ACKNOWLEDGE = "OTA_INSTALL_NOW_ACKNOWLEDGE"

--- a/src/rivian/rivian.py
+++ b/src/rivian/rivian.py
@@ -57,12 +57,14 @@ BASE_HEADERS = {
     "Apollographql-Client-Name": APOLLO_CLIENT_NAME,
 }
 
-CLOUD_CONNECTION_TEMPLATE = "{ lastSync }"
-LOCATION_TEMPLATE = "{ latitude longitude timeStamp }"
+CLOUD_CONNECTION_TEMPLATE = "{ lastSync isOnline }"
+LOCATION_TEMPLATE = "{ latitude longitude timeStamp isAuthorized }"
+LOCATION_ERROR_TEMPLATE = "{ timeStamp positionVertical positionHorizontal speed bearing }"
 VALUE_TEMPLATE = "{ timeStamp value }"
 TEMPLATE_MAP = {
     "cloudConnection": CLOUD_CONNECTION_TEMPLATE,
     "gnssLocation": LOCATION_TEMPLATE,
+    "gnssError": LOCATION_ERROR_TEMPLATE,
 }
 
 LIVE_SESSION_VALUE_RECORD_KEYS = {

--- a/src/rivian/rivian.py
+++ b/src/rivian/rivian.py
@@ -59,7 +59,9 @@ BASE_HEADERS = {
 
 CLOUD_CONNECTION_TEMPLATE = "{ lastSync isOnline }"
 LOCATION_TEMPLATE = "{ latitude longitude timeStamp isAuthorized }"
-LOCATION_ERROR_TEMPLATE = "{ timeStamp positionVertical positionHorizontal speed bearing }"
+LOCATION_ERROR_TEMPLATE = (
+    "{ timeStamp positionVertical positionHorizontal speed bearing }"
+)
 VALUE_TEMPLATE = "{ timeStamp value }"
 TEMPLATE_MAP = {
     "cloudConnection": CLOUD_CONNECTION_TEMPLATE,

--- a/src/rivian/schemas/gateway.graphql
+++ b/src/rivian/schemas/gateway.graphql
@@ -46,6 +46,7 @@ type Mutation {
   ): MobileLoginResponse
   logout: LogoutResponse
   resendOTPCode(otpToken: String!): ResendOTPCodeResponse
+  sendTripToVehicle(attrs: SendTripToVehicleInput!) { sendTripToVehicle(attrs: $attrs) }
   sendVehicleCommand(attrs: VehicleCommandAttributes!): SendVehicleCommandState
   setChargingSchedules(
     vehicleId: String!
@@ -208,6 +209,8 @@ type ChargingLiveData {
   price: Float
   currency: String
   isFreeSession: Boolean
+  vehicleChargerState: String!
+  startTime: Float!
 }
 
 type ChargingSchedule {
@@ -615,6 +618,9 @@ type VehicleState {
   chargingDisabledAll: TimeStampedInt
   chargingTimeEstimationValidity: TimeStampedString
 
+  chargingTripTargetSoc: TimeStampedInt
+  chargingTripTargetMinsRemaining: TimeStampedInt
+
   closureChargePortDoorNextAction: TimeStampedString @subscriptionOnly
   closureFrunkClosed: TimeStampedString
   closureFrunkLocked: TimeStampedString
@@ -659,6 +665,8 @@ type VehicleState {
   gearGuardVideoStatus: TimeStampedString
   gearGuardVideoTermsAccepted: TimeStampedString
   gearStatus: TimeStampedString
+
+  geoLocation: TimeStampedString
 
   gnssAltitude: TimeStampedNullableFloat
   gnssBearing: TimeStampedFloat

--- a/src/rivian/schemas/gateway.graphql
+++ b/src/rivian/schemas/gateway.graphql
@@ -46,7 +46,7 @@ type Mutation {
   ): MobileLoginResponse
   logout: LogoutResponse
   resendOTPCode(otpToken: String!): ResendOTPCodeResponse
-  sendTripToVehicle(attrs: SendTripToVehicleInput!) { sendTripToVehicle(attrs: $attrs) }
+  sendTripToVehicle(attrs: SendTripToVehicleInput!): OK
   sendVehicleCommand(attrs: VehicleCommandAttributes!): SendVehicleCommandState
   setChargingSchedules(
     vehicleId: String!


### PR DESCRIPTION
Looking through some decompiled smali code this evening, I've ported over some of the subscription and query `vehicleState` attributes that were found.

testing `query vehicleState` against my T returned the following data elements successfully

```
{
    "data": {
        "vehicleState": {
            "__typename": "VehicleState",
            "geoLocation": {
                "value": "Unknown",
                "timeStamp": "2025-03-09T18:33:13.000Z"
            },
            "cloudConnection": {
                "lastSync": "2025-03-11T06:08:29.005Z",
                "isOnline": false
            },
            "gnssLocation": {
                "latitude": 0,
                "longitude": 0,
                "timeStamp": "2025-03-08T17:28:00.000Z",
                "isAuthorized": false
            },
            "gnssError": {
                "timeStamp": "2025-03-11T06:08:26.000Z",
                "positionVertical": 1.54,
                "positionHorizontal": 3.1,
                "speed": 0.03,
                "bearing": 1.0738
            },
            "chargingDisabledAll": {
                "timeStamp": "2025-03-11T04:46:29.000Z",
                "value": 0
            },
            "chargePortState": {
                "timeStamp": "2025-03-09T18:58:57.000Z",
                "value": "open"
            },
            "limitedAccelCold": {
                "timeStamp": "2025-03-11T06:07:15.000Z",
                "value": 0
            },
            "limitedRegenCold": {
                "timeStamp": "2025-03-11T06:07:15.000Z",
                "value": 0
            },
            "rearHitchStatus": null
        }
    }
}
```

A few of the cloud commands aren't new and some have been available for over a year, though given Gen2 isn't owned by a maintainer we never added them in. Of course to execute these successfully one would need a paired key to a Gen2 which isn't widely adopted by integrations (including HomeAssistant) at this point in time.

- "HONK_AND_FLASH_LIGHTS"
- "ACTIVATE_EXTERNAL_SOUND"
- "FLASH_EXTERNAL_LIGHTS"
- "CABIN_HVAC_THIRD_ROW_LEFT_SEAT_HEAT"
- "CABIN_HVAC_THIRD_ROW_RIGHT_SEAT_HEAT"
- "OPEN_CHARGE_PORT_DOOR"
- "CLOSE_CHARGE_PORT_DOOR"