### PR TITLE
Fix for deprecated getLiveSessionData

### DIFF
--- a/src/rivian/rivian.py
+++ b/src/rivian/rivian.py
@@ -477,15 +477,15 @@ class Rivian:
             for p in properties
         )
         graphql_query = f"""
-            query getLiveSessionData($vehicleId: ID!) {{
-                getLiveSessionData(vehicleId: $vehicleId) {{
+            query getLiveSessionHistory($vehicleId: ID!) {{
+                getLiveSessionHistory(vehicleId: $vehicleId) {{
                     __typename
                     {fragment}
                 }}
             }}"""
 
         graphql_json = {
-            "operationName": "getLiveSessionData",
+            "operationName": "getLiveSessionHistory",
             "query": graphql_query,
             "variables": {"vehicleId": vin},
         }

--- a/src/rivian/schemas/charging.graphql
+++ b/src/rivian/schemas/charging.graphql
@@ -1,7 +1,6 @@
 type Query {
   chargepoint: ChargepointQuery
   getCompletedSessionSummaries($vehicleId: String): [ChargingSessionSummary]
-  getLiveSessionData(vehicleId: ID!): LiveSessionData
   getLiveSessionHistory(vehicleId: ID!): LiveSessionHistory
   getNonRivianUserSession: NonRivianUserSessionData
   getRegisteredWallboxes: [WallboxRecord]

--- a/tests/responses.py
+++ b/tests/responses.py
@@ -37,7 +37,7 @@ CSRF_TOKEN_RESPONSE = {
 }
 LIVE_CHARGING_SESSION_RESPONSE = {
     "data": {
-        "getLiveSessionData": {
+        "getLiveSessionHistory": {
             "isRivianCharger": None,
             "isFreeSession": None,
             "vehicleChargerState": {

--- a/tests/rivian_test.py
+++ b/tests/rivian_test.py
@@ -175,7 +175,7 @@ async def test_get_vehicle_state(aresponses: ResponsesMockServer) -> None:
 
 
 async def test_get_live_charging_session(aresponses: ResponsesMockServer) -> None:
-    """Test GraphQL Response for a getLiveSessionData request"""
+    """Test GraphQL Response for a getLiveSessionHistory request"""
     aresponses.add(
         "rivian.com",
         "/api/gql/chrg/user/graphql",
@@ -188,7 +188,7 @@ async def test_get_live_charging_session(aresponses: ResponsesMockServer) -> Non
         response_json = await response.json()
         assert response.status == 200
         assert (
-            response_json["data"]["getLiveSessionData"]["vehicleChargerState"]["value"]
+            response_json["data"]["getLiveSessionHistory"]["vehicleChargerState"]["value"]
             == "charging_active"
         )
         await rivian.close()


### PR DESCRIPTION
Applying the suggested fixes discussed in https://github.com/bretterer/home-assistant-rivian/issues/254. Tests also updated and passing.

Will require a fix in the HA custom component [here](https://github.com/bretterer/home-assistant-rivian/blob/4279cc16903cc3adf571a74fe591296c0cf36825/custom_components/rivian/coordinator.py#L128) by also replacing `getLiveSessionData` with `getLiveSessionHistory`.