### PR TITLE
feat: add charging schedule API methods

### DIFF
--- a/src/rivian/rivian.py
+++ b/src/rivian/rivian.py
@@ -446,6 +446,20 @@ class Rivian:
 
         return await self.__graphql_query(headers, url, graphql_json)
 
+    async def get_charging_schedules(self, vehicle_id: str) -> ClientResponse:
+        """Get charging schedules for a vehicle."""
+        url = GRAPHQL_GATEWAY
+        headers = BASE_HEADERS | {
+            "A-Sess": self._app_session_token,
+            "U-Sess": self._user_session_token,
+        }
+        graphql_json = {
+            "operationName": "getVehicleChargingSchedules",
+            "query": "query getVehicleChargingSchedules($vehicleId: String!) {\n  getVehicle(id: $vehicleId) {\n    chargingSchedules {\n      weekDays\n      startTime\n      duration\n      location {\n        latitude\n        longitude\n      }\n      amperage\n      enabled\n    }\n  }\n}",
+            "variables": {"vehicleId": vehicle_id},
+        }
+        return await self.__graphql_query(headers, url, graphql_json)
+
     async def get_vehicle_ota_update_details(self, vehicle_id: str) -> ClientResponse:
         """Get vehicle OTA update details."""
         url = GRAPHQL_GATEWAY

--- a/src/rivian/rivian.py
+++ b/src/rivian/rivian.py
@@ -460,6 +460,26 @@ class Rivian:
         }
         return await self.__graphql_query(headers, url, graphql_json)
 
+    async def set_charging_schedules(
+        self, vehicle_id: str, schedules: list[dict[str, Any]]
+    ) -> ClientResponse:
+        """Set charging schedules for a vehicle."""
+        url = GRAPHQL_GATEWAY
+        headers = BASE_HEADERS | {
+            "Csrf-Token": self._csrf_token,
+            "A-Sess": self._app_session_token,
+            "U-Sess": self._user_session_token,
+        }
+        graphql_json = {
+            "operationName": "setChargingSchedules",
+            "query": "mutation setChargingSchedules($vehicleId: String!, $chargingSchedules: [InputChargingSchedule!]!) {\n  setChargingSchedules(vehicleId: $vehicleId, chargingSchedules: $chargingSchedules) {\n    success\n  }\n}",
+            "variables": {
+                "vehicleId": vehicle_id,
+                "chargingSchedules": schedules,
+            },
+        }
+        return await self.__graphql_query(headers, url, graphql_json)
+
     async def get_vehicle_ota_update_details(self, vehicle_id: str) -> ClientResponse:
         """Get vehicle OTA update details."""
         url = GRAPHQL_GATEWAY

--- a/src/rivian/rivian.py
+++ b/src/rivian/rivian.py
@@ -472,7 +472,7 @@ class Rivian:
         }
         graphql_json = {
             "operationName": "setChargingSchedules",
-            "query": "mutation setChargingSchedules($vehicleId: String!, $chargingSchedules: [InputChargingSchedule!]!) {\n  setChargingSchedules(vehicleId: $vehicleId, chargingSchedules: $chargingSchedules) {\n    success\n  }\n}",
+            "query": "mutation setChargingSchedules($vehicleId: String!, $chargingSchedules: [InputChargingSchedule!]!) {\n  setChargingSchedules(vehicleId: $vehicleId, chargingSchedules: $chargingSchedules) {\n    __typename\n    success\n  }\n}",
             "variables": {
                 "vehicleId": vehicle_id,
                 "chargingSchedules": schedules,

--- a/tests/responses.py
+++ b/tests/responses.py
@@ -672,6 +672,15 @@ DISENROLL_PHONE_BAD_REQUEST_RESPONSE = {
 }
 
 
+SET_CHARGING_SCHEDULES_RESPONSE = {
+    "data": {
+        "setChargingSchedules": {
+            "success": True
+        }
+    }
+}
+
+
 VEHICLE_CHARGING_SCHEDULES_RESPONSE = {
     "data": {
         "getVehicle": {

--- a/tests/responses.py
+++ b/tests/responses.py
@@ -672,13 +672,7 @@ DISENROLL_PHONE_BAD_REQUEST_RESPONSE = {
 }
 
 
-SET_CHARGING_SCHEDULES_RESPONSE = {
-    "data": {
-        "setChargingSchedules": {
-            "success": True
-        }
-    }
-}
+SET_CHARGING_SCHEDULES_RESPONSE = {"data": {"setChargingSchedules": {"success": True}}}
 
 
 VEHICLE_CHARGING_SCHEDULES_RESPONSE = {

--- a/tests/responses.py
+++ b/tests/responses.py
@@ -672,6 +672,32 @@ DISENROLL_PHONE_BAD_REQUEST_RESPONSE = {
 }
 
 
+VEHICLE_CHARGING_SCHEDULES_RESPONSE = {
+    "data": {
+        "getVehicle": {
+            "chargingSchedules": [
+                {
+                    "weekDays": [
+                        "Monday",
+                        "Tuesday",
+                        "Wednesday",
+                        "Thursday",
+                        "Friday",
+                        "Saturday",
+                        "Sunday",
+                    ],
+                    "startTime": 0,
+                    "duration": 1440,
+                    "location": {"latitude": 37.7749, "longitude": -122.4194},
+                    "amperage": 32,
+                    "enabled": True,
+                }
+            ]
+        }
+    }
+}
+
+
 def error_response(
     code: str | None = None, reason: str | None = None
 ) -> dict[str, Any]:

--- a/tests/rivian_test.py
+++ b/tests/rivian_test.py
@@ -24,6 +24,7 @@ from .responses import (
     LIVE_CHARGING_SESSION_RESPONSE,
     OTP_TOKEN_RESPONSE,
     USER_INFORMATION_RESPONSE,
+    VEHICLE_CHARGING_SCHEDULES_RESPONSE,
     VEHICLE_STATE_RESPONSE,
     WALLBOXES_RESPONSE,
     error_response,
@@ -194,6 +195,27 @@ async def test_get_live_charging_session(aresponses: ResponsesMockServer) -> Non
             response_json["data"]["getLiveSessionData"]["vehicleChargerState"]["value"]
             == "charging_active"
         )
+        await rivian.close()
+
+
+async def test_get_charging_schedules(aresponses: ResponsesMockServer) -> None:
+    """Test getting vehicle charging schedules."""
+    aresponses.add(
+        "rivian.com",
+        "/api/gql/gateway/graphql",
+        "POST",
+        response=VEHICLE_CHARGING_SCHEDULES_RESPONSE,
+    )
+    async with aiohttp.ClientSession():
+        rivian = Rivian(app_session_token="token", user_session_token="token")
+        response = await rivian.get_charging_schedules("vehicle_id")
+        response_json = await response.json()
+        assert response.status == 200
+        schedules = response_json["data"]["getVehicle"]["chargingSchedules"]
+        assert len(schedules) == 1
+        assert schedules[0]["amperage"] == 32
+        assert schedules[0]["enabled"] is True
+        assert len(schedules[0]["weekDays"]) == 7
         await rivian.close()
 
 

--- a/tests/rivian_test.py
+++ b/tests/rivian_test.py
@@ -23,6 +23,7 @@ from .responses import (
     CSRF_TOKEN_RESPONSE,
     LIVE_CHARGING_SESSION_RESPONSE,
     OTP_TOKEN_RESPONSE,
+    SET_CHARGING_SCHEDULES_RESPONSE,
     USER_INFORMATION_RESPONSE,
     VEHICLE_CHARGING_SCHEDULES_RESPONSE,
     VEHICLE_STATE_RESPONSE,
@@ -216,6 +217,45 @@ async def test_get_charging_schedules(aresponses: ResponsesMockServer) -> None:
         assert schedules[0]["amperage"] == 32
         assert schedules[0]["enabled"] is True
         assert len(schedules[0]["weekDays"]) == 7
+        await rivian.close()
+
+
+async def test_set_charging_schedules(aresponses: ResponsesMockServer) -> None:
+    """Test setting vehicle charging schedules."""
+    aresponses.add(
+        "rivian.com",
+        "/api/gql/gateway/graphql",
+        "POST",
+        response=SET_CHARGING_SCHEDULES_RESPONSE,
+    )
+    async with aiohttp.ClientSession():
+        rivian = Rivian(
+            csrf_token="csrf",
+            app_session_token="token",
+            user_session_token="token",
+        )
+        schedules = [
+            {
+                "weekDays": [
+                    "Monday",
+                    "Tuesday",
+                    "Wednesday",
+                    "Thursday",
+                    "Friday",
+                    "Saturday",
+                    "Sunday",
+                ],
+                "startTime": 0,
+                "duration": 1440,
+                "location": {"latitude": 37.7749, "longitude": -122.4194},
+                "amperage": 16,
+                "enabled": True,
+            }
+        ]
+        response = await rivian.set_charging_schedules("vehicle_id", schedules)
+        response_json = await response.json()
+        assert response.status == 200
+        assert response_json["data"]["setChargingSchedules"]["success"] is True
         await rivian.close()
 
 


### PR DESCRIPTION
## Summary

Adds two new methods to the `Rivian` class for managing vehicle charging schedules:

- **`get_charging_schedules(vehicle_id)`** — Queries `getVehicle` to fetch the current charging schedules, returning fields: `weekDays`, `startTime`, `duration`, `location`, `amperage`, `enabled`
- **`set_charging_schedules(vehicle_id, schedules)`** — Sends the `setChargingSchedules` GraphQL mutation to update the full schedule array

### Why

The Rivian API exposes charge amperage control through charging schedules (the `SetChargingSchedule` GraphQL mutation), but the Python client has no methods for it. This has been requested in the HA integration repo (issues [#153](https://github.com/bretterer/home-assistant-rivian/issues/153), [#221](https://github.com/bretterer/home-assistant-rivian/issues/221), [#244](https://github.com/bretterer/home-assistant-rivian/issues/244)) to enable charge current control for energy management systems like [evcc](https://evcc.io).

### Implementation

Both methods follow the existing codebase patterns exactly:

- **`get_charging_schedules`**: Read-only query using `A-Sess` + `U-Sess` headers (no CSRF, matching other query methods). Uses the `getVehicle` root query to access `chargingSchedules` on the `Vehicle` type, which is already defined in the gateway schema.
- **`set_charging_schedules`**: Mutation using `Csrf-Token` + `A-Sess` + `U-Sess` headers (matching `send_vehicle_command`, `enroll_phone`, etc.). Sends `InputChargingSchedule` objects with fields: `weekDays`, `startTime`, `duration`, `location` (`CoordinatesInput`), `amperage`, `enabled`.

Both use inline GraphQL strings, `GRAPHQL_GATEWAY` endpoint, and return `ClientResponse` via `__graphql_query` — consistent with every other method in the class.

### GraphQL types (from `gateway.graphql` schema)

```graphql
input InputChargingSchedule {
  weekDays: [String!]!
  startTime: Int!
  duration: Int!
  location: CoordinatesInput!
  amperage: Int!
  enabled: Boolean!
}

type ChargingSchedule {
  startTime: Int!
  duration: Int!
  location: GeoCoordinates!
  amperage: Int!
  enabled: Boolean!
  weekDays: [String!]!
}
```

## Test plan

- [x] Added `test_get_charging_schedules` — mocks gateway, verifies response parsing (schedule count, amperage, enabled, weekDays)
- [x] Added `test_set_charging_schedules` — mocks gateway, verifies mutation with CSRF token succeeds
- [x] Full test suite passes (17/17)
- [x] Tested end-to-end via the [home-assistant-rivian](https://github.com/bretterer/home-assistant-rivian) integration against a real Rivian vehicle — confirmed read and write of charging schedules works correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)