### PR TITLE
fix(parallax): sum active segment durations for timeElapsed calculation

### DIFF
--- a/src/rivian/parallax.py
+++ b/src/rivian/parallax.py
@@ -251,18 +251,19 @@ def decode_charging_graph_global(payload: str) -> dict[str, Any]:
         ]
 
         first_seg = active_segments[0] if active_segments else segments[0]
-        last_seg = active_segments[-1] if active_segments else segments[-1]
         result: dict[str, Any] = {}
 
         if "start_ms" in first_seg:
             st = datetime.fromtimestamp(first_seg["start_ms"] / 1000, timezone.utc)
             result["startTime"] = st.strftime("%Y-%m-%dT%H:%M:%S.%f%z")
 
-        if active_segments and "start_ms" in first_seg and "end_ms" in last_seg:
-            result["timeElapsed"] = max(
-                0, int((last_seg["end_ms"] - first_seg["start_ms"]) / 1000)
+        if active_segments:
+            result["timeElapsed"] = sum(
+                max(0, int((s["end_ms"] - s["start_ms"]) / 1000))
+                for s in active_segments
+                if "end_ms" in s and "start_ms" in s
             )
-        elif not active_segments:
+        else:
             result["timeElapsed"] = 0
 
         latest_segment = segments[-1]

--- a/tests/test_parallax.py
+++ b/tests/test_parallax.py
@@ -185,6 +185,50 @@ def test_decode_charging_graph_global_stopped_state() -> None:
     assert result.get("kilometersChargedPerHour") == 0.0
 
 
+def test_decode_charging_graph_global_resumed_session() -> None:
+    """Test charging graph when charging resumes after an idle pause."""
+    # Active Segment 1: 1785695977217 -> 1785696037217 (60s, 5.8 kW, state=3)
+    seg1 = (
+        b"\x08\x48"
+        + bytes([21])
+        + struct.pack("<f", 5.8)
+        + b"\x18\x81\xfe\x98\x9e\xfc3"
+        + b"\x20\xe1\xd2\x9c\x9e\xfc3"
+        + b"\x30\x03"
+    )
+    # Idle Segment 2: 1785696037217 -> 1785696637217 (600s pause, state=8)
+    seg2 = (
+        b"\x08\x48"
+        + b"\x18\xe1\xd2\x9c\x9e\xfc3"
+        + b"\x20\xa1\xa9\xb8\x9e\xfc3"
+        + b"\x30\x08"
+    )
+    # Active Segment 3: 1785696637217 -> 1785696757217 (120s resumed, 5.8 kW, state=3)
+    seg3 = (
+        b"\x08\x48"
+        + bytes([21])
+        + struct.pack("<f", 5.8)
+        + b"\x18\xa1\xa2\xc1\x9e\xfc3"
+        + b"\x20\xe1\xcb\xc8\x9e\xfc3"
+        + b"\x30\x03"
+    )
+    outer = (
+        bytes([10, len(seg1)])
+        + seg1
+        + bytes([10, len(seg2)])
+        + seg2
+        + bytes([10, len(seg3)])
+        + seg3
+    )
+    payload_b64 = base64.b64encode(outer).decode()
+
+    result = decode_charging_graph_global(payload_b64)
+    # timeElapsed must equal sum of active segments (60s + 120s = 180s), ignoring the 600s gap
+    assert result.get("timeElapsed") == 180
+    assert result.get("power") == 5.8
+    assert "startTime" in result
+
+
 def test_decode_charging_session_status() -> None:
     """Test charging.session.status decoder."""
     # field 1 = plugConnectionStatus (1), field 2 = displayStatus (3), field 3 = evseType (2)


### PR DESCRIPTION
### Summary
When a vehicle charges in multiple bursts (e.g. charging started, paused/stopped, and resumed while remaining plugged in), `energy_edge_compute.graphs.charging_graph_global` contains active segments separated by idle/suspended segments.

Previously, `timeElapsed` calculated `last_seg_end - first_seg_start`, which included the idle paused duration in the total elapsed charge time.

This PR updates `decode_charging_graph_global` to sum the durations of `active_segments` directly so that `timeElapsed` accurately reflects active charging time and ignores idle/suspended intervals.

### Changes
- Sum individual active segment durations in `decode_charging_graph_global`
- Remove unused `last_seg` variable
- Add unit test `test_decode_charging_graph_global_resumed_session`